### PR TITLE
Expand dependency ranges for Nix 22.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for yesod-auth-oidc
 
+## 0.1.2
+
++ add support for `oidc-client` versions from `0.7` onward
++ add support for `reroute` versions from `0.7` onwards
+
 ## 0.1.1
 
 + add ghc9 support

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,6 +1,6 @@
 let
-  # release-21.11, committed on May 23 2022
-  rev = "a790b646e0634695782876f45d98f93c38ceae1d";
+  # release-22.11, committed on Nov 30 2022
+  rev = "4d2b37a84fad1091b9de401eb450aae66f1a741e";
   url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
 in
   import (builtins.fetchTarball url)

--- a/yesod-auth-oidc.cabal
+++ b/yesod-auth-oidc.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: yesod-auth-oidc
-version: 0.1.1
+version: 0.1.2
 build-type: Simple
 category: Web, Yesod
 extra-source-files: README.md

--- a/yesod-auth-oidc.cabal
+++ b/yesod-auth-oidc.cabal
@@ -102,7 +102,7 @@ Common test-properties
     yesod-auth,
     broch                             >= 0.1 && < 0.2,
     postgresql-simple                 >= 0.6.4 && < 0.7,
-    reroute                           >= 0.6.0 && < 0.7,
+    reroute                           >= 0.6.0 && < 0.8,
     sqlite-simple                     >= 0.4.18 && < 0.5,
     hspec                             >= 2.7.10 && < 3.0,
     lens                              >= 4.19.2 && < 6.0,

--- a/yesod-auth-oidc.cabal
+++ b/yesod-auth-oidc.cabal
@@ -15,6 +15,7 @@ description:
   Authorization Code flow (AKA server flow).
 
   Please see the README.md file for more documentation.
+extensions: CPP
 
 tested-with: GHC == 8.10.4
 
@@ -44,7 +45,7 @@ common common-options
       http-client                       >= 0.6.4 && < 1,
       jose-jwt                          >= 0.9.2 && < 0.10,
 
-      oidc-client                       >= 0.6.0 && < 0.7,
+      oidc-client                       >= 0.6.0 && < 0.8,
 
       shakespeare                       >= 2.0.25 && < 2.1,
 


### PR DESCRIPTION
A couple of dependencies have breaking changes between the versions available on 22.05 and 22.11, which is a blocker to us upgrading our packages. These changes expand the supported dependency ranges of the library to remove that blocker.